### PR TITLE
Use dmb ish instead of dmb st and dmb sy

### DIFF
--- a/rpmalloc/rpmalloc.c
+++ b/rpmalloc/rpmalloc.c
@@ -85,8 +85,8 @@
 #    define _Thread_local __thread
 #  endif
 #  ifdef __arm__
-#    define atomic_thread_fence_acquire() __asm volatile("dmb sy" ::: "memory")
-#    define atomic_thread_fence_release() __asm volatile("dmb st" ::: "memory")
+#    define atomic_thread_fence_acquire() __asm volatile("dmb ish" ::: "memory")
+#    define atomic_thread_fence_release() __asm volatile("dmb ish" ::: "memory")
 #  else
 #    define atomic_thread_fence_acquire() //__asm volatile("" ::: "memory")
 #    define atomic_thread_fence_release() //__asm volatile("" ::: "memory")

--- a/rpmalloc/rpmalloc.c
+++ b/rpmalloc/rpmalloc.c
@@ -86,7 +86,7 @@
 #  endif
 #  ifdef __arm__
 #    define atomic_thread_fence_acquire() __asm volatile("dmb ish" ::: "memory")
-#    define atomic_thread_fence_release() __asm volatile("dmb ish" ::: "memory")
+#    define atomic_thread_fence_release() __asm volatile("dmb ishst" ::: "memory")
 #  else
 #    define atomic_thread_fence_acquire() //__asm volatile("" ::: "memory")
 #    define atomic_thread_fence_release() //__asm volatile("" ::: "memory")


### PR DESCRIPTION
I had problems building rpmalloc using GCC 7.2.0 on Slackware ARM, and got many of these errors:

    Error: selected processor does not support `dmb sy' in ARM mode
    Error: selected processor does not support `dmb st' in ARM mode

Looking at https://gcc.gnu.org/ml/gcc-patches/2014-11/msg01272.html, it seems that it is safe to replace `dmb sy` (and I assume) `dmb st` with `dmb ish`. I could then compile rpmalloc and everything seems to work fine (I could use programs that depend on rpmalloc fine).

Note that I haven't run any sort of extensive tests, and I'm not entirely sure if `dmb ish` is the correct replacement for `dmb st`, but this should work.