### PR TITLE
Avoid redefining assert macro.

### DIFF
--- a/rpmalloc/rpmalloc.c
+++ b/rpmalloc/rpmalloc.c
@@ -113,6 +113,7 @@
 #if ENABLE_ASSERTS
 #  include <assert.h>
 #else
+#  undef  assert
 #  define assert(x)
 #endif
 


### PR DESCRIPTION
If assert.h has been included via a prefix header then redefining it will cause a macro redefinition warning.

This could be handled by setting ENABLE_ASSERTS based on the existing value of NDEBUG, but this patch assumes that ENABLE_ASSERTS should win out and so any existing assert() is removed before the no-op version is defined.