### PR TITLE
Fix cast errors when compiling with clang.

### DIFF
--- a/rpmalloc/rpmalloc.c
+++ b/rpmalloc/rpmalloc.c
@@ -911,12 +911,12 @@ _memory_allocate_heap(void) {
 	//Try getting an orphaned heap
 	atomic_thread_fence_acquire();
 	do {
-		raw_heap = (uintptr_t)atomic_load_ptr(&_memory_orphan_heaps);
+		raw_heap = (uintptr_t)(void*)atomic_load_ptr(&_memory_orphan_heaps);
 		heap = (void*)(raw_heap & ~(uintptr_t)0xFFFF);
 		if (!heap)
 			break;
 		next_heap = heap->next_orphan;
-		orphan_counter = atomic_incr32(&_memory_orphan_counter);
+		orphan_counter = (uintptr_t)atomic_incr32(&_memory_orphan_counter);
 		next_raw_heap = (uintptr_t)next_heap | (orphan_counter & 0xFFFF);
 	}
 	while (!atomic_cas_ptr(&_memory_orphan_heaps, (void*)next_raw_heap, (void*)raw_heap));
@@ -1565,7 +1565,7 @@ rpmalloc_thread_finalize(void) {
 	do {
 		last_heap = atomic_load_ptr(&_memory_orphan_heaps);
 		heap->next_orphan = (void*)((uintptr_t)last_heap & ~(uintptr_t)0xFFFF);
-		orphan_counter = atomic_incr32(&_memory_orphan_counter);
+		orphan_counter = (uintptr_t)atomic_incr32(&_memory_orphan_counter);
 		raw_heap = (uintptr_t)heap | (orphan_counter & 0xFFFF);
 	}
 	while (!atomic_cas_ptr(&_memory_orphan_heaps, (void*)raw_heap, last_heap));


### PR DESCRIPTION
Fixes some cast errors when compiling with clang (Xcode 9.2). Build output before the patch is:

```
$ clang -v
Apple LLVM version 9.0.0 (clang-900.0.39.2)
Target: x86_64-apple-darwin17.3.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin

$ ninja
[1/32] CC rpmalloc/rpmalloc.c
FAILED: build/ninja/macosx/release/x86-64/rpmalloc-1bd9049/rpmalloc-fbf40dc.o 
PATH=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/usr/bin:/Applications/Xcode.app/Contents/Developer/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang -MMD -MT build/ninja/macosx/release/x86-64/rpmalloc-1bd9049/rpmalloc-fbf40dc.o -MF build/ninja/macosx/release/x86-64/rpmalloc-1bd9049/rpmalloc-fbf40dc.o.d -I.   -DRPMALLOC_COMPILE=1 -funit-at-a-time -fstrict-aliasing -fno-math-errno -ffinite-math-only -funsafe-math-optimizations -fno-trapping-math -ffast-math -fasm-blocks -mmacosx-version-min=10.7 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk -fembed-bitcode-marker -x c -std=c11 -W -Werror -pedantic -Wall -Weverything -Wno-padded -Wno-documentation-unknown-command -arch x86_64 -DBUILD_RELEASE=1 -O3 -g -funroll-loops  -c rpmalloc/rpmalloc.c -o build/ninja/macosx/release/x86-64/rpmalloc-1bd9049/rpmalloc-fbf40dc.o
rpmalloc/rpmalloc.c:914:25: error: cast from function call of type 'void *' to non-matching type 'uintptr_t' (aka 'unsigned long') [-Werror,-Wbad-function-cast]
                raw_heap = (uintptr_t)atomic_load_ptr(&_memory_orphan_heaps);
                                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
rpmalloc/rpmalloc.c:919:20: error: implicit conversion changes signedness: 'int32_t' (aka 'int') to 'uintptr_t' (aka 'unsigned long') [-Werror,-Wsign-conversion]
                orphan_counter = atomic_incr32(&_memory_orphan_counter);
                               ~ ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
rpmalloc/rpmalloc.c:1568:20: error: implicit conversion changes signedness: 'int32_t' (aka 'int') to 'uintptr_t' (aka 'unsigned long') [-Werror,-Wsign-conversion]
                orphan_counter = atomic_incr32(&_memory_orphan_counter);
                               ~ ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
3 errors generated.

```

