### PR TITLE
Super spans

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,8 @@ Fixed an issue where an allocation of maximum large block size (2097120 bytes) w
 
 Fixed an issue where memory pages at start of aligned span run was not completely unmapped on POSIX systems.
 
+Fixed an issue where spans were not correctly marked as owned by the heap after traversing the global span cache.
+
 Added function to access the allocator configuration after initialization to find default values.
 
 Removed allocated and reserved statistics to reduce code complexity.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
-1.2.3
+1.3.0
 
 Make span size configurable and all spans equal in size, removing span size classes and streamlining the thread cache.
+
+Allow super spans to be reserved in advance and split up in multiple used spans to reduce number of system calls. This will not increase committed physical pages, only reserved virtual memory space.
 
 Fixed an issue where an allocation of zero bytes would cause a segmentation fault from indexing size class array with index -1.
 
@@ -9,6 +11,8 @@ Fixed an issue where an allocation of maximum large block size (2097120 bytes) w
 Fixed an issue where memory pages at start of aligned span run was not completely unmapped on POSIX systems.
 
 Added function to access the allocator configuration after initialization to find default values.
+
+Removed allocated and reserved statistics to reduce code complexity.
 
 
 1.2.2

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Please consider our Patreon to support our work - https://www.patreon.com/rampan
 Created by Mattias Jansson ([@maniccoder](https://twitter.com/maniccoder)) / Rampant Pixels - http://www.rampantpixels.com
 
 # Performance
-We believe rpmalloc is faster than most popular memory allocators like tcmalloc, hoard, ptmalloc3 and others without causing extra allocated memory overhead in the thread caches compared to these allocators. We also believe the implementation to be easier to read and modify compared to these allocators, as it is a single source file of ~2000 lines of C code.
+We believe rpmalloc is faster than most popular memory allocators like tcmalloc, hoard, ptmalloc3 and others without causing extra allocated memory overhead in the thread caches compared to these allocators. We also believe the implementation to be easier to read and modify compared to these allocators, as it is a single source file of ~2100 lines of C code.
 
 Contained in a parallel repository is a benchmark utility that performs interleaved allocations (both aligned to 8 or 16 bytes, and unaligned) and deallocations (both in-thread and cross-thread) in multiple threads. It measures number of memory operations performed per CPU second, as well as memory overhead by comparing the virtual memory mapped with the number of bytes requested in allocation calls. The setup of number of thread, cross-thread deallocation rate and allocation size limits is configured by command line arguments.
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Please consider our Patreon to support our work - https://www.patreon.com/rampan
 Created by Mattias Jansson ([@maniccoder](https://twitter.com/maniccoder)) / Rampant Pixels - http://www.rampantpixels.com
 
 # Performance
-We believe rpmalloc is faster than most popular memory allocators like tcmalloc, hoard, ptmalloc3 and others without causing extra allocated memory overhead in the thread caches compared to these allocators. We also believe the implementation to be easier to read and modify compared to these allocators, as it is a single source file of ~2100 lines of C code.
+We believe rpmalloc is faster than most popular memory allocators like tcmalloc, hoard, ptmalloc3 and others without causing extra allocated memory overhead in the thread caches compared to these allocators. We also believe the implementation to be easier to read and modify compared to these allocators, as it is a single source file of ~2000 lines of C code.
 
 Contained in a parallel repository is a benchmark utility that performs interleaved allocations (both aligned to 8 or 16 bytes, and unaligned) and deallocations (both in-thread and cross-thread) in multiple threads. It measures number of memory operations performed per CPU second, as well as memory overhead by comparing the virtual memory mapped with the number of bytes requested in allocation calls. The setup of number of thread, cross-thread deallocation rate and allocation size limits is configured by command line arguments.
 
@@ -97,7 +97,9 @@ By default the allocator uses OS APIs to map virtual memory pages as needed, eit
 
 The functions must guarantee alignment to the configured span size. Either provide the span size during initialization using __rpmalloc_initialize_config__, or use __rpmalloc_config__ to find the required alignment which is equal to the span size. The span size MUST be a power of two in [512, 262144] range, and be a multiple (or divisor) of the memory page size.
 
-Memory mapping requests are always done in multiples of the span size or memory page size, whichever is larger. You can specify a custom page size when initializing rpmalloc with __rpmalloc_initialize_config__, or pass 0 to let rpmalloc determine the system memory page size using OS APIs. The page size MUST be a power of two in [512, 16384] range.
+Memory mapping requests are always done in multiples of the memory page size, whichever is larger. You can specify a custom page size when initializing rpmalloc with __rpmalloc_initialize_config__, or pass 0 to let rpmalloc determine the system memory page size using OS APIs. The page size MUST be a power of two in [512, 16384] range.
+
+To reduce system call overhead, memory spans are mapped in batches controlled by the `span_map_count` configuration variable (which defaults to the `DEFAULT_SPAN_MAP_COUNT` value if 0, which in turn is sized according to the cache configuration define, defaulting to 8). If the platform can handle partial unmaps (unmapping one or more spans of memory pages mapped in a larger batch) the `unmap_partial` configuration variable should be set to non-zero. If not, spans will be kept until the entire batch can be unmapped.
 
 # Memory guards
 If you define the __ENABLE_GUARDS__ to 1, all memory allocations will be padded with extra guard areas before and after the memory block (while still honoring the requested alignment). These dead zones will be filled with a pattern and checked when the block is freed. If the patterns are not intact the callback set in initialization config is called, or if not set an assert is fired.

--- a/rpmalloc/rpmalloc.c
+++ b/rpmalloc/rpmalloc.c
@@ -1791,8 +1791,9 @@ _memory_map_os(size_t size, size_t* offset) {
 static void
 _memory_unmap_os(void* address, size_t size, size_t offset) {
 	if (offset) {
-		size += _memory_span_size;
-		address = pointer_offset(address, -(offset_t)(offset << 2));
+		offset <<= 2;
+		size += offset;
+		address = pointer_offset(address, -(offset_t)offset);
 	}
 #ifdef PLATFORM_WINDOWS
 	(void)sizeof(size);

--- a/rpmalloc/rpmalloc.c
+++ b/rpmalloc/rpmalloc.c
@@ -492,12 +492,12 @@ _memory_counter_increase(span_counter_t* counter, uint32_t* global_counter) {
 		counter->max_allocations = counter->current_allocations;
 #if MAX_SPAN_CACHE_DIVISOR > 0
 		counter->cache_limit = counter->max_allocations / MAX_SPAN_CACHE_DIVISOR;
-		if (counter->cache_limit > 65534)
-			counter->cache_limit = 65534;
+		if (counter->cache_limit > (_memory_span_size - 2))
+			counter->cache_limit = (_memory_span_size - 2);
 		if (counter->cache_limit < (MIN_SPAN_CACHE_RELEASE + MIN_SPAN_CACHE_SIZE))
 			counter->cache_limit = (MIN_SPAN_CACHE_RELEASE + MIN_SPAN_CACHE_SIZE);
 #else
-		counter->cache_limit = 65534;
+		counter->cache_limit = (_memory_span_size - 2);
 #endif
 		if (counter->max_allocations > *global_counter)
 			*global_counter = counter->max_allocations;

--- a/rpmalloc/rpmalloc.c
+++ b/rpmalloc/rpmalloc.c
@@ -325,7 +325,7 @@ struct span_t {
 	uint16_t    flags;
 	//! Span data
 	span_data_t data;
-	//! Next span and flags/counter
+	//! Next span
 	span_t*     next_span;
 	//! Previous span
 	span_t*     prev_span;

--- a/rpmalloc/rpmalloc.h
+++ b/rpmalloc/rpmalloc.h
@@ -48,10 +48,6 @@ typedef struct rpmalloc_global_statistics_t {
 } rpmalloc_global_statistics_t;
 
 typedef struct rpmalloc_thread_statistics_t {
-	//! Amount of memory currently requested in allocations (only if ENABLE_STATISTICS=1)
-	size_t requested;
-	//! Amount of memory actually allocated in memory blocks (only if ENABLE_STATISTICS=1)
-	size_t allocated;
 	//! Current number of bytes available for allocation from active spans
 	size_t active;
 	//! Current number of bytes available in thread size class caches

--- a/rpmalloc/rpmalloc.h
+++ b/rpmalloc/rpmalloc.h
@@ -85,6 +85,15 @@ typedef struct rpmalloc_config_t {
 	//  Set to 0 to use the default span size. All memory mapping requests to memory_map will be made with
 	//  size set to a multiple of the span size.
 	size_t span_size;
+	//! Number of spans to map at each request to map new virtual memory blocks. This can
+	//  be used to minimize the system call overhead at the cost of virtual memory address
+	//  space. The extra mapped pages will not be written until actually used, so physical
+	//  committed memory should not be affected in the default implementation.
+	size_t span_map_count;
+	//! Set to 1 if partial ranges can be unmapped of a mapped span of memory pages (like munmap
+	//  on POSIX systems). Set to 0 if the entire span needs to be unmapped at the same time (like
+	//  VirtualFree with MEM_RELEASE on Windows).
+	int unmap_partial;
 	//! Debug callback if memory guards are enabled. Called if a memory overwrite is detected
 	void (*memory_overwrite)(void* address);
 } rpmalloc_config_t;

--- a/rpmalloc/rpmalloc.h
+++ b/rpmalloc/rpmalloc.h
@@ -72,7 +72,9 @@ typedef struct rpmalloc_config_t {
 	//  Optionally the function can store an alignment offset in the offset variable
 	//  in case it performs alignment and the returned pointer is offset from the
 	//  actual start of the memory region due to this alignment. The alignment offset
-	//  will be passed to the memory unmap function.
+	//  will be passed to the memory unmap function. The alignment offset MUST NOT be
+	//  larger than 65535 (storable in an uint16_t), if it is you must use natural
+	//  alignment to shift it into 16 bits.
 	void* (*memory_map)(size_t size, size_t* offset);
 	//! Unmap the memory pages starting at address and spanning the given number of bytes.
 	//  The address, size and offset variables will always be a value triple as used


### PR DESCRIPTION
Allow super spans to be pre-reserved and broken up on free to reduce number of system calls and allow freed spans from large allocations to be used as cache spans for small/medium allocations