### PR TITLE
Fix for the ninja/configuire.py

### DIFF
--- a/build/ninja/generator.py
+++ b/build/ninja/generator.py
@@ -74,7 +74,7 @@ class Generator(object):
     configure_env = dict((key, os.environ[key]) for key in os.environ if key in env_keys)
     if configure_env:
       config_str = ' '.join([key + '=' + pipes.quote(configure_env[key]) for key in configure_env])
-      writer.variable('configure_env', config_str + '$ ')
+      self.writer.variable('configure_env', config_str + '$ ')
 
     if variables is None:
       variables = {}


### PR DESCRIPTION
Without the fix I get:

```
$ ./configure.py -a x86-64 --toolchain gcc --host linux
Traceback (most recent call last):
  File "./configure.py", line 12, in <module>
    generator = generator.Generator(project = 'rpmalloc', variables = [('bundleidentifier', 'com.rampantpixels.rpmalloc.$(binname)')])
  File "build/ninja/generator.py", line 77, in __init__
    writer.variable('configure_env', config_str + '$ ')
NameError: global name 'writer' is not defined
```